### PR TITLE
OSPF support tweaks

### DIFF
--- a/lib/puppet/provider/mikrotik_ospf_area_range/mikrotik_api.rb
+++ b/lib/puppet/provider/mikrotik_ospf_area_range/mikrotik_api.rb
@@ -1,0 +1,44 @@
+require 'puppet/provider/mikrotik_api'
+
+Puppet::Type.type(:mikrotik_ospf_area_range).provide(:mikrotik_api, :parent => Puppet::Provider::Mikrotik_Api) do
+  confine :feature => :mtik
+  
+  mk_resource_methods
+
+  def self.instances    
+    ospf_area_ranges = Puppet::Provider::Mikrotik_Api::get_all("/routing/ospf/area/range")
+    instances = ospf_area_ranges.collect { |ospf_area_range| ospfAreaRange(ospf_area_range) }    
+    instances
+  end
+  
+  def self.ospfAreaRange(data)
+      new(
+        :ensure    => :present,
+        :name      => data['range'],
+        :area      => data['area'],
+        :cost      => data['cost'],
+        :advertise => data['advertise'],
+        :comment   => data['comment']
+      )
+  end
+
+  def flush
+    Puppet.debug("Flushing OSPF Area Range #{resource[:name]}/#{resource[:area]}")
+
+    params = {}
+    params["range"]     = resource[:name]
+    params["area"]      = resource[:area]
+    params["cost"]      = resource[:cost]
+    params["advertise"] = resource[:advertise]
+    params["comment"]   = resource[:comment] if ! resource[:comment].nil?
+
+    lookup = {
+      "range" => resource[:name],
+      "area"  => resource[:area]
+    }
+    
+    Puppet.debug("Params: #{params.inspect} - Lookup: #{lookup.inspect}")
+
+    simple_flush("/routing/ospf/area/range", params, lookup)
+  end  
+end

--- a/lib/puppet/provider/mikrotik_ospf_interface/mikrotik_api.rb
+++ b/lib/puppet/provider/mikrotik_ospf_interface/mikrotik_api.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:mikrotik_ospf_interface).provide(:mikrotik_api, :parent => Pu
 
   def self.instances    
     ospf_interfaces = Puppet::Provider::Mikrotik_Api::get_all("/routing/ospf/interface")
-    instances = ospf_interfaces.collect { |ospf_interface| ospfInterface(ospf_interface) }    
+    instances = ospf_interfaces.reject {|data| data['dynamic'] == 'true' }.collect { |ospf_interface| ospfInterface(ospf_interface) }
     instances
   end
 

--- a/lib/puppet/provider/mikrotik_ospf_network/mikrotik_api.rb
+++ b/lib/puppet/provider/mikrotik_ospf_network/mikrotik_api.rb
@@ -13,9 +13,10 @@ Puppet::Type.type(:mikrotik_ospf_network).provide(:mikrotik_api, :parent => Pupp
   
   def self.ospfNetwork(data)
       new(
-        :ensure => :present,
-        :name   => data['network'],
-        :area   => data['area']
+        :ensure  => :present,
+        :name    => data['network'],
+        :area    => data['area'],
+        :comment => data['comment'],
       )
   end
 
@@ -25,6 +26,7 @@ Puppet::Type.type(:mikrotik_ospf_network).provide(:mikrotik_api, :parent => Pupp
     params = {}
     params["network"] = resource[:name]
     params["area"] = resource[:area] if ! resource[:area].nil?
+    params["comment"] = resource[:comment] if ! resource[:comment].nil?
 
     lookup = {}
     lookup["network"] = resource[:name]

--- a/lib/puppet/type/mikrotik_ospf_area_range.rb
+++ b/lib/puppet/type/mikrotik_ospf_area_range.rb
@@ -1,0 +1,44 @@
+require 'puppet/property/boolean'
+
+Puppet::Type.newtype(:mikrotik_ospf_area_range) do
+  apply_to_all
+  
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+  
+  newparam(:name) do
+    desc 'the network prefix of this range'
+    isnamevar
+  end
+  
+  newparam(:area) do
+    desc 'The OSPF area associated with this range (name, not id)'
+    isnamevar
+  end
+  
+  newproperty(:cost) do
+    desc "The cost of the summary LSA this range will create. 'calculated' will use the largest cost of all routes in the range" 
+    newvalues(/^\d+$/,:calculated)
+    defaultto :calculated
+  end
+
+  newproperty(:advertise, boolean: true, parent: Puppet::Property::Boolean) do
+    desc 'Whether to create the summary LSA and advertise it to adjacent areas'
+    defaultto true
+  end
+
+  newproperty(:comment) do
+    desc "A comment describing this area range"
+  end
+
+  autorequire(:mikrotik_ospf_area) { self[:area] }
+
+  # the actual 'title' of the resource is just the 'range' parameter;
+  # the 'area' parameter must be set explicitly, not as part of the title.
+  # This is exactly how the official 'package' resource works.
+  def self.title_patterns
+    [ [ /(.*)/, [ [:name] ] ] ]
+  end
+end

--- a/lib/puppet/type/mikrotik_ospf_network.rb
+++ b/lib/puppet/type/mikrotik_ospf_network.rb
@@ -14,4 +14,8 @@ Puppet::Type.newtype(:mikrotik_ospf_network) do
   newproperty(:area) do
     desc 'The OSPF Area this network belongs to.'
   end
+
+  newproperty(:comment) do
+    desc 'A comment that describes this network'
+  end
 end


### PR DESCRIPTION
This PR:
* Adds support for OSPF area ranges
* Adds support for comments on OSPF networks
* Excludes dynamic objects from the OSPF interfaces `instances` list, because they cannot be adjusted via `set`, they must be replaced via `add` as if they didn't exist in the first place.