### PR TITLE
Fix transport typo

### DIFF
--- a/lib/puppet/util/network_device/transport/mikrotik.rb
+++ b/lib/puppet/util/network_device/transport/mikrotik.rb
@@ -9,13 +9,13 @@ class Puppet::Util::NetworkDevice::Transport::Mikrotik < Puppet::Util::NetworkDe
 
   def initialize(url, _options = {})
     require 'uri'
-    
+
     url_object = URI(url)
 
     if (url_object.scheme == 'api')
-      @connection = MTik::Connection.new :host => url_object.host, :user => url_object.user, :pass => url_object.password, :unecrypted_plaintext => true, :conn_timeout => 10
-    else 
-      raise "The Mikrotik module currently only support API access. Use api:// in URL."  
-    end    
+      @connection = MTik::Connection.new :host => url_object.host, :user => url_object.user, :pass => url_object.password, :unencrypted_plaintext => true, :conn_timeout => 10
+    else
+      raise "The Mikrotik module currently only support API access. Use api:// in URL."
+    end
   end
 end


### PR DESCRIPTION
This fixes a typo in the transport class regarding 6.45+ support.